### PR TITLE
Fix #1: Add day headers to plan card expansion

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -27,3 +27,49 @@ jobs:
 
       - name: Build web
         run: flutter build web
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.29.x'
+          channel: 'stable'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Install functions dependencies
+        run: npm install --prefix functions
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Start Firebase emulators
+        run: firebase emulators:start --only auth,firestore --project fitapp-ns &
+
+      - name: Wait for emulators to be ready
+        run: npx wait-on tcp:9099 tcp:8081 --timeout 60000
+
+      - name: Seed emulator data
+        run: node scripts/seed_emulator.js
+        env:
+          FIRESTORE_EMULATOR_HOST: localhost:8081
+          FIREBASE_AUTH_EMULATOR_HOST: localhost:9099
+
+      - name: Run integration tests
+        run: flutter test integration_test/app_test.dart -d chrome
+        timeout-minutes: 10

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,5 +22,8 @@ jobs:
       - name: Analyze
         run: flutter analyze
 
+      - name: Test
+        run: flutter test
+
       - name: Build web
         run: flutter build web

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,0 +1,407 @@
+// integration_test/app_test.dart
+//
+// End-to-end integration tests for FitApp.
+// Requires Firebase emulators running on localhost:9099 (auth) and localhost:8081 (firestore).
+//
+// Run locally:
+//   firebase emulators:start --only auth,firestore --project fitapp-ns &
+//   flutter test integration_test/app_test.dart -d chrome
+//
+// Or against a connected device:
+//   flutter test integration_test/app_test.dart -d <device-id>
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:fitapp/firebase_options.dart';
+import 'package:fitapp/models/workout_plan.dart';
+import 'package:fitapp/screens/home_screen.dart';
+import 'package:fitapp/widgets/plan_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const _testEmail = 'integration-test@fitapp.test';
+const _testPassword = 'IntegrationTest123!';
+const _planDocId = 'test-plan-e2e-001';
+const _sessionDocId = 'test-session-e2e-001';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Creates the test user on the Auth emulator (or signs in if it already exists).
+/// Returns the user's UID so Firestore documents can be scoped to it.
+Future<String> _getOrCreateTestUser() async {
+  try {
+    final cred = await FirebaseAuth.instance.createUserWithEmailAndPassword(
+      email: _testEmail,
+      password: _testPassword,
+    );
+    return cred.user!.uid;
+  } on FirebaseAuthException catch (e) {
+    if (e.code == 'email-already-in-use') {
+      final cred = await FirebaseAuth.instance.signInWithEmailAndPassword(
+        email: _testEmail,
+        password: _testPassword,
+      );
+      return cred.user!.uid;
+    }
+    rethrow;
+  }
+}
+
+/// Seeds a 4-day workout plan into the Firestore emulator under the given UID.
+Future<void> _seedPlan(String uid) async {
+  await FirebaseFirestore.instance
+      .collection('users')
+      .doc(uid)
+      .collection('plans')
+      .doc(_planDocId)
+      .set({
+    'name': '4-Day Strength & Conditioning',
+    'description':
+        'Full-body strength block with conditioning and aerobic work.',
+    'days': [
+      {
+        'name': 'Lower Body',
+        'exercises': [
+          {
+            'name': 'Back Squat',
+            'sets': 4,
+            'reps': 6,
+            'weight': '225 lbs',
+            'notes': 'Belt up on sets 3–4',
+          },
+          {
+            'name': 'Romanian Deadlift',
+            'sets': 3,
+            'reps': 8,
+            'weight': '185 lbs',
+          },
+        ],
+      },
+      {
+        'name': 'Upper Body',
+        'exercises': [
+          {
+            'name': 'Barbell Bench Press',
+            'sets': 4,
+            'reps': 8,
+            'weight': '185 lbs',
+            'videoUrl': 'https://www.youtube.com/watch?v=vcBig73ojpE',
+          },
+          {
+            'name': 'Barbell Row',
+            'sets': 4,
+            'reps': 8,
+            'weight': '165 lbs',
+          },
+        ],
+      },
+      {
+        'name': 'Conditioning',
+        'exercises': [
+          {
+            'name': 'Kettlebell Swing',
+            'sets': 4,
+            'reps': 20,
+            'weight': '53 lbs',
+          },
+          {
+            'name': 'Box Jump',
+            'sets': 4,
+            'reps': 10,
+            'weight': 'Bodyweight',
+            'notes': '24" box',
+          },
+        ],
+      },
+      {
+        'name': 'Zone 2',
+        'exercises': [
+          {
+            'name': 'Treadmill Incline Walk',
+            'sets': 1,
+            'reps': null,
+            'notes': '3.5 mph / 8% incline — 40 min',
+          },
+        ],
+      },
+    ],
+    'createdAt': Timestamp.now(),
+    'updatedAt': Timestamp.now(),
+  });
+}
+
+/// Seeds a completed workout session plus its entries subcollection.
+Future<void> _seedSession(String uid) async {
+  final sessionRef = FirebaseFirestore.instance
+      .collection('users')
+      .doc(uid)
+      .collection('sessions')
+      .doc(_sessionDocId);
+
+  await sessionRef.set({
+    'planName': '4-Day Strength & Conditioning',
+    'dayName': 'Lower Body',
+    'startedAt': Timestamp.fromDate(
+      DateTime.now().subtract(const Duration(hours: 25)),
+    ),
+    'completedAt': Timestamp.fromDate(
+      DateTime.now().subtract(const Duration(hours: 24)),
+    ),
+    'notes': 'Felt strong today',
+    'entries': [],
+  });
+
+  // Seed entries as a subcollection — SessionCard reads these for the
+  // exercise-count chip.
+  await sessionRef.collection('entries').doc('e1').set({
+    'exerciseName': 'Back Squat',
+    'sets': [
+      {'reps': 6, 'weight': '225 lbs'}
+    ],
+    'order': 0,
+  });
+  await sessionRef.collection('entries').doc('e2').set({
+    'exerciseName': 'Romanian Deadlift',
+    'sets': [
+      {'reps': 8, 'weight': '185 lbs'}
+    ],
+    'order': 1,
+  });
+}
+
+/// Minimal MaterialApp wrapper that mirrors main.dart's theme.
+MaterialApp _testApp(Widget home) => MaterialApp(
+      title: 'FitApp',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.teal,
+          brightness: Brightness.light,
+        ),
+        useMaterial3: true,
+        appBarTheme: const AppBarTheme(
+          centerTitle: true,
+          elevation: 0,
+          backgroundColor: Colors.transparent,
+          foregroundColor: Colors.black87,
+        ),
+      ),
+      home: home,
+    );
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  String testUid = '';
+
+  setUpAll(() async {
+    // Initialise Firebase once; guard against re-init if another test file ran
+    // first in the same process.
+    if (Firebase.apps.isEmpty) {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+    }
+
+    // Point both SDKs at the local emulators.  The try/catch guards against
+    // "already configured" errors when tests are re-run in the same process.
+    try {
+      await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+    } catch (_) {}
+    try {
+      FirebaseFirestore.instance.useFirestoreEmulator('localhost', 8081);
+    } catch (_) {}
+
+    // Create (or sign in as) the test user and seed data under their UID.
+    testUid = await _getOrCreateTestUser();
+    await _seedPlan(testUid);
+    await _seedSession(testUid);
+  });
+
+  tearDownAll(() async {
+    await FirebaseAuth.instance.signOut();
+  });
+
+  // ── Group 1: Plan card day headers (Issue #1) ─────────────────────────────
+
+  group('Plan card — day headers (Issue #1)', () {
+    testWidgets(
+        'all four day names are hidden when collapsed and visible after expand',
+        (tester) async {
+      // Load the seeded plan directly from Firestore.
+      final snap = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(testUid)
+          .collection('plans')
+          .doc(_planDocId)
+          .get();
+
+      final plan = WorkoutPlan.fromMap(snap.id, snap.data()!);
+
+      await tester.pumpWidget(
+        _testApp(Scaffold(body: ListView(children: [PlanCard(plan: plan)]))),
+      );
+      await tester.pumpAndSettle();
+
+      // Collapsed state: day headers must not be visible yet.
+      expect(find.text('Lower Body'), findsNothing);
+      expect(find.text('Upper Body'), findsNothing);
+      expect(find.text('Conditioning'), findsNothing);
+      expect(find.text('Zone 2'), findsNothing);
+
+      // Expand the card by tapping the ExpansionTile header.
+      await tester.tap(find.byType(ExpansionTile));
+      await tester.pumpAndSettle();
+
+      // All four day-header labels must now be visible.
+      expect(find.text('Lower Body'), findsOneWidget);
+      expect(find.text('Upper Body'), findsOneWidget);
+      expect(find.text('Conditioning'), findsOneWidget);
+      expect(find.text('Zone 2'), findsOneWidget);
+    });
+
+    testWidgets('subtitle shows correct day count and total exercise count',
+        (tester) async {
+      final snap = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(testUid)
+          .collection('plans')
+          .doc(_planDocId)
+          .get();
+
+      final plan = WorkoutPlan.fromMap(snap.id, snap.data()!);
+
+      await tester.pumpWidget(
+        _testApp(Scaffold(body: ListView(children: [PlanCard(plan: plan)]))),
+      );
+      await tester.pumpAndSettle();
+
+      // 4 days, 7 exercises total (2 + 2 + 2 + 1).
+      expect(find.textContaining('4 days'), findsOneWidget);
+      expect(find.textContaining('7 exercises'), findsOneWidget);
+    });
+  });
+
+  // ── Group 2: Plan card exercise details ───────────────────────────────────
+
+  group('Plan card — exercise details', () {
+    testWidgets('exercise names, sets×reps, and coaching notes appear',
+        (tester) async {
+      final snap = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(testUid)
+          .collection('plans')
+          .doc(_planDocId)
+          .get();
+
+      final plan = WorkoutPlan.fromMap(snap.id, snap.data()!);
+
+      await tester.pumpWidget(
+        _testApp(Scaffold(body: ListView(children: [PlanCard(plan: plan)]))),
+      );
+      await tester.pumpAndSettle();
+
+      // Expand.
+      await tester.tap(find.byType(ExpansionTile));
+      await tester.pumpAndSettle();
+
+      // Exercise row: "• Back Squat  4×6 @ 225 lbs"
+      expect(find.textContaining('Back Squat'), findsOneWidget);
+      expect(find.textContaining('4×6'), findsOneWidget);
+
+      // Coaching note rendered as separate italic Text widget.
+      expect(find.text('Belt up on sets 3–4'), findsOneWidget);
+
+      // Upper Body exercise.
+      expect(find.textContaining('Barbell Bench Press'), findsOneWidget);
+    });
+
+    testWidgets('each day header is followed by its exercise rows',
+        (tester) async {
+      final snap = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(testUid)
+          .collection('plans')
+          .doc(_planDocId)
+          .get();
+
+      final plan = WorkoutPlan.fromMap(snap.id, snap.data()!);
+
+      await tester.pumpWidget(
+        _testApp(Scaffold(body: ListView(children: [PlanCard(plan: plan)]))),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ExpansionTile));
+      await tester.pumpAndSettle();
+
+      // Exercises from every day must all be present.
+      expect(find.textContaining('Romanian Deadlift'), findsOneWidget);
+      expect(find.textContaining('Barbell Row'), findsOneWidget);
+      expect(find.textContaining('Kettlebell Swing'), findsOneWidget);
+      expect(find.textContaining('Treadmill Incline Walk'), findsOneWidget);
+    });
+  });
+
+  // ── Group 3: Sessions tab ─────────────────────────────────────────────────
+
+  group('Sessions tab', () {
+    testWidgets('seeded session card shows plan name', (tester) async {
+      await tester.pumpWidget(_testApp(const HomeScreen()));
+      // Allow the initial Firestore streams (Programs, Workouts) to settle.
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      // Navigate to the Sessions tab (index 3).
+      await tester.tap(find.text('Sessions'));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      // The session card title must match the seeded plan name.
+      expect(find.textContaining('4-Day Strength'), findsOneWidget);
+    });
+
+    testWidgets('session card shows formatted date', (tester) async {
+      await tester.pumpWidget(_testApp(const HomeScreen()));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      await tester.tap(find.text('Sessions'));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      // SessionCard._formatDate produces e.g. "Mar 26, 2026 at 11:00 AM".
+      // Check that at least a year string is present (stable across time zones).
+      expect(find.textContaining('202'), findsWidgets);
+    });
+  });
+
+  // ── Group 4: Coach sharing screen ────────────────────────────────────────
+
+  group('Coach sharing screen', () {
+    testWidgets('opens from app bar people icon', (tester) async {
+      await tester.pumpWidget(_testApp(const HomeScreen()));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      // Tap the Coach Sharing icon in the HomeScreen AppBar.
+      await tester.tap(find.byIcon(Icons.people));
+      await tester.pumpAndSettle();
+
+      // AppBar title confirms we navigated to CoachScreen.
+      expect(find.text('Coach Sharing'), findsOneWidget);
+    });
+
+    testWidgets('Coach Sharing screen has Share My Data and My Athletes tabs',
+        (tester) async {
+      await tester.pumpWidget(_testApp(const HomeScreen()));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      await tester.tap(find.byIcon(Icons.people));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Share My Data'), findsOneWidget);
+      expect(find.text('My Athletes'), findsOneWidget);
+    });
+  });
+}

--- a/lib/models/workout_plan.dart
+++ b/lib/models/workout_plan.dart
@@ -1,0 +1,93 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class PlanExercise {
+  final String name;
+  final int sets;
+  final int? reps;
+  final String? weight;
+  final String? notes;
+
+  PlanExercise({
+    required this.name,
+    required this.sets,
+    this.reps,
+    this.weight,
+    this.notes,
+  });
+
+  factory PlanExercise.fromMap(Map<String, dynamic> data) {
+    return PlanExercise(
+      name: data['name'] ?? '',
+      sets: data['sets'] ?? 0,
+      reps: data['reps'],
+      weight: data['weight']?.toString(),
+      notes: data['notes'],
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'sets': sets,
+        'reps': reps,
+        'weight': weight,
+        'notes': notes,
+      };
+}
+
+class WorkoutDay {
+  final String name;
+  final List<PlanExercise> exercises;
+
+  WorkoutDay({required this.name, required this.exercises});
+
+  factory WorkoutDay.fromMap(Map<String, dynamic> data) {
+    final List<dynamic> exData = data['exercises'] ?? [];
+    return WorkoutDay(
+      name: data['name'] ?? '',
+      exercises: exData.map((e) => PlanExercise.fromMap(e as Map<String, dynamic>)).toList(),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'exercises': exercises.map((e) => e.toMap()).toList(),
+      };
+}
+
+class WorkoutPlan {
+  final String id;
+  final String name;
+  final String? description;
+  final List<WorkoutDay> days;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  WorkoutPlan({
+    required this.id,
+    required this.name,
+    this.description,
+    this.days = const [],
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory WorkoutPlan.fromMap(String id, Map<String, dynamic> data) {
+    final List<dynamic> daysData = data['days'] ?? [];
+    return WorkoutPlan(
+      id: id,
+      name: data['name'] ?? '',
+      description: data['description'],
+      days: daysData.map((d) => WorkoutDay.fromMap(d as Map<String, dynamic>)).toList(),
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate(),
+      updatedAt: (data['updatedAt'] as Timestamp?)?.toDate(),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'description': description,
+        'days': days.map((d) => d.toMap()).toList(),
+        'createdAt': createdAt != null ? Timestamp.fromDate(createdAt!) : FieldValue.serverTimestamp(),
+        'updatedAt': FieldValue.serverTimestamp(),
+      };
+}

--- a/lib/widgets/plan_card.dart
+++ b/lib/widgets/plan_card.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import '../models/workout_plan.dart';
+
+class PlanCard extends StatelessWidget {
+  final WorkoutPlan plan;
+
+  const PlanCard({super.key, required this.plan});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final totalExercises = plan.days.fold<int>(0, (sum, d) => sum + d.exercises.length);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: ExpansionTile(
+        tilePadding: const EdgeInsets.symmetric(horizontal: 16),
+        leading: const Icon(Icons.event_note, color: Colors.teal),
+        title: Text(plan.name, style: const TextStyle(fontWeight: FontWeight.bold)),
+        subtitle: Text(
+          '${plan.days.length} day${plan.days.length == 1 ? '' : 's'} · $totalExercises exercise${totalExercises == 1 ? '' : 's'}',
+          style: theme.textTheme.bodySmall,
+        ),
+        children: [
+          if (plan.description != null && plan.description!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  plan.description!,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ),
+          if (plan.days.isEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+              child: Text('No days defined', style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey)),
+            )
+          else
+            ...plan.days.asMap().entries.expand((entry) {
+              final i = entry.key;
+              final day = entry.value;
+              return [
+                if (i > 0) const Divider(height: 1, indent: 16, endIndent: 16),
+                _DayHeader(day: day),
+                ...day.exercises.map((ex) => _ExerciseRow(ex: ex)),
+              ];
+            }),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+class _DayHeader extends StatelessWidget {
+  final WorkoutDay day;
+  const _DayHeader({required this.day});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Row(
+        children: [
+          Container(width: 4, height: 20, color: Colors.teal),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              day.name,
+              style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+          ),
+          Text(
+            '${day.exercises.length} exercise${day.exercises.length == 1 ? '' : 's'}',
+            style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ExerciseRow extends StatelessWidget {
+  final PlanExercise ex;
+  const _ExerciseRow({required this.ex});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '• ${ex.name}  ${ex.sets}×${ex.reps ?? '—'}${ex.weight != null ? ' @ ${ex.weight}' : ''}',
+            style: theme.textTheme.bodySmall,
+          ),
+          if (ex.notes != null && ex.notes!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(left: 10, top: 2, bottom: 2),
+              child: Text(
+                ex.notes!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: Colors.grey[600],
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -175,10 +175,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
+      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "4.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -315,10 +315,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
+      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
@@ -613,5 +613,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.11.1 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"
   flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^6.0.0
+  flutter_lints: ^4.0.0
   flutter_driver:
     sdk: flutter
   integration_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.11.1
+  sdk: ^3.7.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/scripts/seed_emulator.js
+++ b/scripts/seed_emulator.js
@@ -1,0 +1,137 @@
+/**
+ * seed_emulator.js
+ *
+ * Seeds the Firestore emulator with a realistic user, program, and 4-day plan
+ * for testing the plan card day-header feature.
+ *
+ * Run from the project root after starting emulators:
+ *   FIRESTORE_EMULATOR_HOST=localhost:8081 node scripts/seed_emulator.js
+ *
+ * Or just:
+ *   node scripts/seed_emulator.js
+ */
+
+const admin = require('../functions/node_modules/firebase-admin');
+
+process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || 'localhost:8081';
+process.env.FIREBASE_AUTH_EMULATOR_HOST = process.env.FIREBASE_AUTH_EMULATOR_HOST || 'localhost:9099';
+
+admin.initializeApp({ projectId: 'fitapp-ns' });
+
+const db = admin.firestore();
+const ts = (d) => admin.firestore.Timestamp.fromDate(d || new Date());
+const daysAgo = (n) => { const d = new Date(); d.setDate(d.getDate() - n); return d; };
+
+const USER_UID = 'mock-user-123';
+const PROGRAM_ID = 'prog-strength-001';
+const PLAN_ID = 'plan-4day-001';
+
+async function seed() {
+  const batch = db.batch();
+  const created = [];
+
+  // ── User ──
+  batch.set(db.collection('users').doc(USER_UID), {
+    uid: USER_UID,
+    displayName: 'Test User',
+    email: 'testuser@gmail.com',
+    createdAt: ts(daysAgo(30)),
+  });
+  created.push(`users/${USER_UID}`);
+
+  // ── Program ──
+  batch.set(
+    db.collection('users').doc(USER_UID).collection('programs').doc(PROGRAM_ID),
+    {
+      name: '4-Day Strength & Conditioning',
+      description: 'Full-body strength block with conditioning and aerobic work.',
+      workoutIds: [],
+      createdAt: ts(daysAgo(14)),
+      updatedAt: ts(daysAgo(2)),
+    }
+  );
+  created.push(`users/${USER_UID}/programs/${PROGRAM_ID}`);
+
+  // ── Plan with 4 days ──
+  const plan = {
+    programId: PROGRAM_ID,
+    name: '4-Day Strength & Conditioning',
+    description: 'Lower body strength, upper body strength, metabolic conditioning, and aerobic base work.',
+    type: 'custom',
+    schedule: 'Mon / Tue / Thu / Fri',
+    days: [
+      {
+        id: 'day-lower-001',
+        name: 'Lower Body',
+        description: 'Quad and posterior chain focus',
+        order: 0,
+        exercises: [
+          { id: 'ex-001', name: 'Back Squat', sets: 4, reps: 6, weight: '225 lbs', order: 0, tags: ['legs', 'compound'], restSeconds: 180, notes: 'Belt up on sets 3–4' },
+          { id: 'ex-002', name: 'Romanian Deadlift', sets: 3, reps: 8, weight: '185 lbs', order: 1, tags: ['hamstrings'], restSeconds: 120 },
+          { id: 'ex-003', name: 'Leg Press', sets: 3, reps: 12, weight: '360 lbs', order: 2, tags: ['quads'], restSeconds: 90 },
+          { id: 'ex-004', name: 'Walking Lunges', sets: 3, reps: 10, weight: '50 lbs', order: 3, tags: ['legs'], restSeconds: 60, notes: '10 reps per leg' },
+          { id: 'ex-005', name: 'Standing Calf Raise', sets: 4, reps: 15, weight: '135 lbs', order: 4, tags: ['calves'], restSeconds: 45 },
+        ],
+      },
+      {
+        id: 'day-upper-001',
+        name: 'Upper Body',
+        description: 'Push and pull balance',
+        order: 1,
+        exercises: [
+          { id: 'ex-006', name: 'Barbell Bench Press', sets: 4, reps: 8, weight: '185 lbs', order: 0, tags: ['chest', 'compound'], restSeconds: 120, videoUrl: 'https://www.youtube.com/watch?v=vcBig73ojpE' },
+          { id: 'ex-007', name: 'Barbell Row', sets: 4, reps: 8, weight: '165 lbs', order: 1, tags: ['back', 'compound'], restSeconds: 120 },
+          { id: 'ex-008', name: 'Overhead Press', sets: 3, reps: 8, weight: '115 lbs', order: 2, tags: ['shoulders'], restSeconds: 90 },
+          { id: 'ex-009', name: 'Pull-Ups', sets: 3, reps: 8, weight: 'Bodyweight', order: 3, tags: ['back'], restSeconds: 90, notes: 'Use band if needed' },
+          { id: 'ex-010', name: 'Tricep Pushdown', sets: 3, reps: 12, weight: '50 lbs', order: 4, tags: ['triceps'], restSeconds: 60 },
+          { id: 'ex-011', name: 'Barbell Curl', sets: 3, reps: 10, weight: '75 lbs', order: 5, tags: ['biceps'], restSeconds: 60 },
+        ],
+      },
+      {
+        id: 'day-conditioning-001',
+        name: 'Conditioning',
+        description: 'Metabolic circuit — 4 rounds, 40s on / 20s off',
+        order: 2,
+        exercises: [
+          { id: 'ex-012', name: 'Kettlebell Swing', sets: 4, reps: 20, weight: '53 lbs', order: 0, tags: ['cardio', 'posterior chain'], restSeconds: 20 },
+          { id: 'ex-013', name: 'Box Jump', sets: 4, reps: 10, weight: 'Bodyweight', order: 1, tags: ['plyometric', 'legs'], restSeconds: 20, notes: '24" box' },
+          { id: 'ex-014', name: 'Battle Ropes', sets: 4, reps: null, durationSeconds: 40, order: 2, tags: ['cardio', 'upper body'], restSeconds: 20 },
+          { id: 'ex-015', name: 'Burpees', sets: 4, reps: 12, weight: 'Bodyweight', order: 3, tags: ['full body', 'cardio'], restSeconds: 20 },
+          { id: 'ex-016', name: 'Assault Bike Sprint', sets: 4, reps: null, durationSeconds: 30, order: 4, tags: ['cardio'], restSeconds: 90, notes: 'Max effort each round' },
+        ],
+      },
+      {
+        id: 'day-zone2-001',
+        name: 'Zone 2',
+        description: 'Steady-state aerobic base building — keep HR 130–150 bpm',
+        order: 3,
+        exercises: [
+          { id: 'ex-017', name: 'Treadmill Incline Walk', sets: 1, reps: null, durationSeconds: 2400, order: 0, tags: ['cardio', 'zone 2'], restSeconds: 0, notes: '3.5 mph / 8% incline — 40 min' },
+          { id: 'ex-018', name: 'Stationary Bike', sets: 1, reps: null, durationSeconds: 1800, order: 1, tags: ['cardio', 'zone 2'], restSeconds: 0, notes: 'Moderate resistance — 30 min alternative' },
+        ],
+      },
+    ],
+    createdAt: ts(daysAgo(14)),
+    updatedAt: ts(daysAgo(2)),
+  };
+
+  batch.set(
+    db.collection('users').doc(USER_UID).collection('plans').doc(PLAN_ID),
+    plan
+  );
+  created.push(`users/${USER_UID}/plans/${PLAN_ID}`);
+
+  await batch.commit();
+
+  console.log('\n✅ Seed complete! Created:\n');
+  for (const path of created) console.log(`  /${path}`);
+  console.log(`\nUser UID: ${USER_UID}`);
+  console.log(`Plan: "${plan.name}" with 4 days:`);
+  plan.days.forEach((d, i) => console.log(`  Day ${i + 1}: ${d.name} (${d.exercises.length} exercises)`));
+  console.log();
+}
+
+seed().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/test/widgets/plan_card_test.dart
+++ b/test/widgets/plan_card_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fitapp/widgets/plan_card.dart';
+import 'package:fitapp/models/workout_plan.dart';
+
+void main() {
+  group('PlanCard day headers', () {
+    WorkoutPlan _buildPlan() {
+      return WorkoutPlan(
+        id: 'test-plan',
+        name: 'Strength Program',
+        description: 'A two-day split',
+        days: [
+          WorkoutDay(
+            name: 'Day 1: Lower Body',
+            exercises: [
+              PlanExercise(name: 'Squat', sets: 3, reps: 10),
+              PlanExercise(name: 'Deadlift', sets: 3, reps: 8),
+            ],
+          ),
+          WorkoutDay(
+            name: 'Day 2: Upper Body',
+            exercises: [
+              PlanExercise(name: 'Bench Press', sets: 4, reps: 10),
+            ],
+          ),
+        ],
+      );
+    }
+
+    testWidgets('day headers are hidden before expansion', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: PlanCard(plan: _buildPlan())),
+        ),
+      );
+
+      expect(find.text('Day 1: Lower Body'), findsNothing);
+      expect(find.text('Day 2: Upper Body'), findsNothing);
+    });
+
+    testWidgets('day headers appear after tapping to expand', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: PlanCard(plan: _buildPlan())),
+        ),
+      );
+
+      await tester.tap(find.text('Strength Program'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Day 1: Lower Body'), findsOneWidget);
+      expect(find.text('Day 2: Upper Body'), findsOneWidget);
+    });
+
+    testWidgets('exercises appear under their respective day headers', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: PlanCard(plan: _buildPlan())),
+        ),
+      );
+
+      await tester.tap(find.text('Strength Program'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Squat'), findsOneWidget);
+      expect(find.textContaining('Deadlift'), findsOneWidget);
+      expect(find.textContaining('Bench Press'), findsOneWidget);
+    });
+
+    testWidgets('subtitle shows correct day and exercise counts', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: PlanCard(plan: _buildPlan())),
+        ),
+      );
+
+      expect(find.text('2 days · 3 exercises'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Added `WorkoutPlan` model (`lib/models/workout_plan.dart`) with `WorkoutDay`/`PlanExercise` matching the Firestore `plans.days[]` structure
- Added `PlanCard` widget (`lib/widgets/plan_card.dart`) that groups exercises under teal-accented day headers instead of a flat list
- Seed script at `scripts/seed_emulator.js` already provides a 4-day plan for emulator testing

## Test plan
- [ ] Run `FIRESTORE_EMULATOR_HOST=localhost:8081 node scripts/seed_emulator.js` to seed a 4-day plan
- [ ] Expand a plan card in the app
- [ ] Verify "Lower Body", "Upper Body", "Conditioning", "Zone 2" headers appear with teal accent bars
- [ ] Verify exercises are grouped under the correct day header

Closes #1