### PR TITLE
Collapse YouTube video tiles by default

### DIFF
--- a/lib/widgets/video_player.dart
+++ b/lib/widgets/video_player.dart
@@ -21,12 +21,6 @@ class VideoLinkTileState extends State<VideoLinkTile> {
   @override
   void initState() {
     super.initState();
-    // Auto-expand on web — ListTile.onTap doesn't receive pointer events
-    // reliably inside CanvasKit scrollable containers (flutter/flutter#54027).
-    // On web we use a raw iframe via HtmlElementView, no controller needed.
-    if (kIsWeb && _videoId != null) {
-      _isExpanded = true;
-    }
   }
 
   String? get _videoId {
@@ -53,12 +47,7 @@ class VideoLinkTileState extends State<VideoLinkTile> {
     if (widget.url != oldWidget.url) {
       _controller?.close();
       _controller = null;
-      final videoId = _videoId;
-      if (kIsWeb && videoId != null) {
-        _isExpanded = true;
-      } else {
-        _isExpanded = false;
-      }
+      _isExpanded = false;
     }
   }
 


### PR DESCRIPTION
## Summary
- YouTube reference videos in plan cards are now collapsed by default on all platforms (including web)
- Removed the web auto-expand workaround that was expanding tiles automatically
- Users tap to expand when they want to watch

## Test plan
- [ ] Open a plan card with a YouTube reference video on web — tile should start collapsed
- [ ] Tap the tile to expand and confirm video loads
- [ ] Tap again to collapse
- [ ] Verify same behavior on mobile (was already collapsed by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)