### PR TITLE
Fix CI: Add Java 21 for Firebase emulators

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Install Flutter dependencies
         run: flutter pub get
 
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
       - name: Start Firebase emulators
         run: firebase emulators:start --only auth,firestore --project fitapp-ns &
 


### PR DESCRIPTION
Firebase Tools now requires Java 21+. The PR Build Check was failing because the emulators couldn't start without it.