### PR TITLE
Fix email capture: allow unauthenticated writes to waitlist collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -38,6 +38,12 @@ service cloud.firestore {
       );
     }
 
+    // Waitlist: unauthenticated users can submit their email; reads are blocked
+    match /waitlist/{email} {
+      allow create: if true;
+      allow read, update, delete: if false;
+    }
+
     // User data: owner has full access; connected coaches get read-only access
     match /users/{uid}/{document=**} {
       allow read, write: if request.auth != null && request.auth.uid == uid;


### PR DESCRIPTION
## Summary
- The email capture form on the Open Source page was showing "Something went wrong" on submission
- Root cause: `firestore.rules` had no rule for the `waitlist` collection, so all writes were denied by Firestore's default-deny policy
- Fix: added a rule allowing unauthenticated `create` on `/waitlist/{email}` while blocking reads, updates, and deletes

## Test plan
- [ ] Submit an email via the Open Source page form — should succeed and show the confirmation state
- [ ] Verify the email doc appears in Firestore under the `waitlist` collection
- [ ] Confirm reads and updates to the collection are still denied (security rules tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)