### PR TITLE
feat: add delete functionality for workout plans and programs

### DIFF
--- a/functions/src/tools/plan-tools.ts
+++ b/functions/src/tools/plan-tools.ts
@@ -124,8 +124,18 @@ export async function handlePlanTool(
 
       case 'delete_workout_program': {
         const { programId } = args as { programId: string };
-        await db.collection(`users/${userId}/programs`).doc(programId).delete();
-        return textResult({ success: true, programId });
+        // Cascade-delete all plans belonging to this program
+        const plansSnapshot = await db
+          .collection(`users/${userId}/plans`)
+          .where('programId', '==', programId)
+          .get();
+        const batch = db.batch();
+        for (const doc of plansSnapshot.docs) {
+          batch.delete(doc.ref);
+        }
+        batch.delete(db.collection(`users/${userId}/programs`).doc(programId));
+        await batch.commit();
+        return textResult({ success: true, programId, deletedPlans: plansSnapshot.size });
       }
 
       case 'create_workout_plan': {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -175,11 +175,28 @@ class _ProgramCard extends StatelessWidget {
   }
 
   Future<void> _deleteProgram(BuildContext context) async {
+    final uid = FirebaseAuth.instance.currentUser!.uid;
+
+    // Query child plans so we can show the count in the dialog and delete them.
+    final plansSnapshot = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(uid)
+        .collection('plans')
+        .where('programId', isEqualTo: program.id)
+        .get();
+    final planCount = plansSnapshot.docs.length;
+
+    if (!context.mounted) return;
+
+    final content = planCount > 0
+        ? 'This will delete the program and all $planCount plan${planCount == 1 ? '' : 's'} underneath it. Linked workouts will become standalone.'
+        : 'Delete this program? Linked workouts will NOT be deleted but will become standalone.';
+
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Delete Program'),
-        content: const Text('Delete this program? Linked workouts will NOT be deleted but will become standalone.'),
+        content: Text(content),
         actions: [
           TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
           TextButton(onPressed: () => Navigator.pop(context, true), child: const Text('Delete', style: TextStyle(color: Colors.red))),
@@ -188,13 +205,14 @@ class _ProgramCard extends StatelessWidget {
     );
 
     if (confirmed == true) {
-      final uid = FirebaseAuth.instance.currentUser!.uid;
-      await FirebaseFirestore.instance
-          .collection('users')
-          .doc(uid)
-          .collection('programs')
-          .doc(program.id)
-          .delete();
+      final batch = FirebaseFirestore.instance.batch();
+      for (final doc in plansSnapshot.docs) {
+        batch.delete(doc.reference);
+      }
+      batch.delete(
+        FirebaseFirestore.instance.collection('users').doc(uid).collection('programs').doc(program.id),
+      );
+      await batch.commit();
     }
   }
 }

--- a/lib/screens/program_detail_screen.dart
+++ b/lib/screens/program_detail_screen.dart
@@ -3,7 +3,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../models/workout_program.dart';
 import '../models/workout.dart';
+import '../models/workout_plan.dart';
 import '../widgets/workout_card.dart';
+import '../widgets/plan_card.dart';
 import 'workout_edit_screen.dart';
 
 class ProgramDetailScreen extends StatelessWidget {
@@ -56,7 +58,44 @@ class ProgramDetailScreen extends StatelessWidget {
           const Divider(),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Text('Workouts in this Program', style: theme.textTheme.titleMedium),
+            child: Text('Plans', style: theme.textTheme.titleMedium),
+          ),
+          StreamBuilder<QuerySnapshot>(
+            stream: FirebaseFirestore.instance
+                .collection('users')
+                .doc(uid)
+                .collection('plans')
+                .where('programId', isEqualTo: program.id)
+                .snapshots(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              }
+              final docs = snapshot.data?.docs ?? [];
+              if (docs.isEmpty) {
+                return Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                  child: Text(
+                    'No plans yet — ask your AI coach to create one.',
+                    style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
+                  ),
+                );
+              }
+              return Column(
+                children: docs.map((doc) {
+                  final plan = WorkoutPlan.fromMap(doc.id, doc.data() as Map<String, dynamic>);
+                  return PlanCard(plan: plan);
+                }).toList(),
+              );
+            },
+          ),
+          const Divider(),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text('Workouts', style: theme.textTheme.titleMedium),
           ),
           Expanded(
             child: StreamBuilder<QuerySnapshot>(

--- a/lib/widgets/plan_card.dart
+++ b/lib/widgets/plan_card.dart
@@ -1,10 +1,42 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import '../models/workout_plan.dart';
 
 class PlanCard extends StatelessWidget {
   final WorkoutPlan plan;
 
   const PlanCard({super.key, required this.plan});
+
+  Future<void> _deletePlan(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Plan'),
+        content: Text('Delete "${plan.name}"? This cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Delete', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      final uid = FirebaseAuth.instance.currentUser!.uid;
+      await FirebaseFirestore.instance
+          .collection('users')
+          .doc(uid)
+          .collection('plans')
+          .doc(plan.id)
+          .delete();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -16,7 +48,20 @@ class PlanCard extends StatelessWidget {
       child: ExpansionTile(
         tilePadding: const EdgeInsets.symmetric(horizontal: 16),
         leading: const Icon(Icons.event_note, color: Colors.teal),
-        title: Text(plan.name, style: const TextStyle(fontWeight: FontWeight.bold)),
+        title: Row(
+          children: [
+            Expanded(
+              child: Text(plan.name, style: const TextStyle(fontWeight: FontWeight.bold)),
+            ),
+            IconButton(
+              icon: const Icon(Icons.delete_outline, color: Colors.red, size: 20),
+              onPressed: () => _deletePlan(context),
+              tooltip: 'Delete Plan',
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+            ),
+          ],
+        ),
         subtitle: Text(
           '${plan.days.length} day${plan.days.length == 1 ? '' : 's'} · $totalExercises exercise${totalExercises == 1 ? '' : 's'}',
           style: theme.textTheme.bodySmall,


### PR DESCRIPTION
## Summary

- **MCP (`plan-tools.ts`)**: `delete_workout_program` now cascade-deletes all child plans (Firestore batch) before removing the program document. Returns `deletedPlans` count in the response.
- **`PlanCard` widget**: Added a red trash icon button in the title row with a confirmation dialog. Deletes via direct Firestore call (`users/{uid}/plans/{planId}`).
- **`program_detail_screen.dart`**: Added a **Plans** section (using `PlanCard`) above the existing Workouts section, so AI-created plans are visible in the UI and the delete button is reachable.
- **`home_screen.dart` `_ProgramCard`**: Before showing the delete dialog, queries child plan count. Dialog text dynamically shows *"This will delete the program and all X plans underneath it"* when plans exist. Uses a Firestore batch to delete plans + program atomically.
- **Session delete**: Already implemented in `SessionCard` — no changes needed.

## Test plan

- [ ] Create a program with 2+ plans via AI coach, open the program card, verify the plan count shows in the delete dialog, confirm deletion removes program + all plans
- [ ] Tap the trash icon on an individual `PlanCard` in the program detail screen, confirm the plan is deleted and disappears from the list
- [ ] Tap the trash icon on a `SessionCard`, confirm the session is removed
- [ ] Delete a program with no plans — dialog should show the old "Linked workouts will become standalone" message (no plan count)
- [ ] Verify `delete_workout_program` MCP tool returns `deletedPlans: N` when called via the AI coach

🤖 Generated with [Claude Code](https://claude.com/claude-code)