### PR TITLE
ci: add Firebase functions deploy to CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,3 +29,17 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           channelId: live
           projectId: fitapp-ns
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Install functions dependencies
+        run: npm --prefix functions install
+
+      - name: Build functions
+        run: npm --prefix functions run build
+
+      - name: Deploy functions
+        run: |
+          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > /tmp/gcp-sa.json
+          GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-sa.json firebase deploy --only functions --project fitapp-ns


### PR DESCRIPTION
## Summary

- Adds a functions deploy step to `.github/workflows/deploy.yml` that runs after the hosting deploy
- Installs Firebase CLI globally, runs `npm install` and `npm run build` in `functions/`, then deploys with `firebase deploy --only functions`
- Uses the existing `FIREBASE_SERVICE_ACCOUNT` secret (same one used for hosting) via `GOOGLE_APPLICATION_CREDENTIALS`

## Test plan

- [ ] Merge a change to `main` and verify the new CI step runs after hosting deploys
- [ ] Confirm all four functions (`createCheckoutSession`, `handleStripeWebhook`, `createPortalSession`, `mcp`) update successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)