### PR TITLE
fix: make program→plan hierarchy explicit in builder-program MCP prompt

### DIFF
--- a/functions/src/prompts.ts
+++ b/functions/src/prompts.ts
@@ -25,22 +25,30 @@ export function getPrompt(name: string, args: Record<string, string>): { message
             type: 'text',
             text: `I want to build a new workout program for ${goal}. Please guide me through this using your FitApp tools.
 
+IMPORTANT — Program → Plan hierarchy:
+A Program is a container that groups multiple Plans. Each Plan represents one workout day (e.g., "Lower Body", "Upper Body"). When creating a program you MUST:
+  1. Create the program first with 'create_workout_program'.
+  2. Then create each workout day as a separate Plan using 'create_workout_plan', passing the programId returned from step 1.
+A program without plans is empty and useless — always follow through and create all plans before finishing.
+
 Follow these steps exactly:
 1. First, suggest a high-level Program name and description based on my goal.
-2. Once I approve the program name, use the 'create_workout_program' tool to create it.
+2. Once I approve the program name, use the 'create_workout_program' tool to create it and note the programId it returns — you will need it for every plan you create.
 3. Next, propose a workout split (e.g., a 3-day or 4-day plan) that fits this program.
-4. For each day in the plan, suggest specific exercises with:
+4. For each day in the split, suggest specific exercises with:
    - sets (number), reps (number, optional), weight (string like "135 lbs", "bodyweight", "medium-light working weight", "RPE 7" — never a bare number, optional)
    - notes: important coaching cues, rep ranges, rest times, RIR targets, form tips, warm-up instructions (put ALL of these in the notes field, NOT in the exercise name)
    - videoUrl: YouTube reference links for complex movements (optional)
 5. Ask me which days of the week I want to do each workout (e.g., "Monday", "Wednesday", "Friday").
-6. Once I approve the plan details, use the 'create_workout_plan' tool to save it with:
-   - programId from step 2
+6. Once I approve the plan details, use the 'create_workout_plan' tool to save each workout day as its own Plan, passing:
+   - programId: the ID returned from 'create_workout_program' in step 2 (REQUIRED — every plan must be linked to the program)
    - schedule set to the day of the week (e.g., "Monday") so it shows up on the right day in the app
    - type set to the workout type (e.g., "strength", "cardio", "conditioning")
+   Repeat this call for every workout day in the split — one 'create_workout_plan' call per day.
 7. Finally, use the 'schedule_session' tool to put these planned workouts onto my FitApp calendar.
 
 Data structure reference for create_workout_plan:
+- programId: string (REQUIRED when building a program — links this plan to its parent program)
 - days: array of { name, exercises: [{ name, sets, reps?, weight?, notes?, videoUrl? }] }
 - schedule: day of week string — IMPORTANT: set this so plans appear on the correct day in the app
 - type: workout category string


### PR DESCRIPTION
## Summary
- Adds a top-level **IMPORTANT** block explaining that a Program is a container and each Plan is one workout day — Claude must create the program first, then create each plan with the returned `programId`
- Updates step 2 to remind Claude to note the `programId` for use in all subsequent plan creation calls
- Updates step 6 to mark `programId` as **REQUIRED** and to repeat the `create_workout_plan` call once per workout day
- Adds `programId` as the first field in the data structure reference for `create_workout_plan`

## Test plan
- [ ] Invoke the `builder-program` MCP prompt and verify Claude creates the program first, then creates each plan with `programId` set
- [ ] Confirm a program with no plans is no longer the end state after a full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)