### PR TITLE
feat: show YouTube video links for plan exercises

### DIFF
--- a/lib/models/workout_plan.dart
+++ b/lib/models/workout_plan.dart
@@ -6,6 +6,7 @@ class PlanExercise {
   final int? reps;
   final String? weight;
   final String? notes;
+  final String? videoUrl;
 
   PlanExercise({
     required this.name,
@@ -13,6 +14,7 @@ class PlanExercise {
     this.reps,
     this.weight,
     this.notes,
+    this.videoUrl,
   });
 
   factory PlanExercise.fromMap(Map<String, dynamic> data) {
@@ -22,6 +24,7 @@ class PlanExercise {
       reps: data['reps'],
       weight: data['weight']?.toString(),
       notes: data['notes'],
+      videoUrl: data['videoUrl'],
     );
   }
 
@@ -31,6 +34,7 @@ class PlanExercise {
         'reps': reps,
         'weight': weight,
         'notes': notes,
+        'videoUrl': videoUrl,
       };
 }
 

--- a/lib/widgets/plan_card.dart
+++ b/lib/widgets/plan_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../models/workout_plan.dart';
+import 'video_player.dart';
 
 class PlanCard extends StatelessWidget {
   final WorkoutPlan plan;
@@ -156,6 +157,14 @@ class _ExerciseRow extends StatelessWidget {
                   color: Colors.grey[600],
                   fontStyle: FontStyle.italic,
                 ),
+              ),
+            ),
+          if (ex.videoUrl != null && ex.videoUrl!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(left: 6),
+              child: VideoLinkTile(
+                url: ex.videoUrl,
+                title: ex.name,
               ),
             ),
         ],


### PR DESCRIPTION
## Summary
- Added `videoUrl` field to `PlanExercise` model with Firestore serialization (`fromMap`/`toMap`)
- Updated `PlanCard._ExerciseRow` to render a `VideoLinkTile` for any exercise that has a `videoUrl` set

## Root cause
The MCP `create_workout_plan` tool accepts `videoUrl` per exercise, but `PlanExercise` had no such field — so the value was silently dropped on read and never displayed.

## Test plan
- [ ] Create a plan via MCP with exercises that include `videoUrl` (YouTube links)
- [ ] Open the Plans tab and expand the plan — exercises with a video URL should show a tappable `VideoLinkTile` below the exercise row
- [ ] Exercises without `videoUrl` should be unaffected
- [ ] Verify existing plans with no video data still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)