### PR TITLE
fix: plan detail scroll overflow + smaller tap-to-open YouTube thumbnail

### DIFF
--- a/lib/screens/program_detail_screen.dart
+++ b/lib/screens/program_detail_screen.dart
@@ -44,61 +44,61 @@ class ProgramDetailScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (program.description != null && program.description!.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Text(
-                program.description!,
-                style: theme.textTheme.bodyMedium?.copyWith(color: Colors.grey[600]),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (program.description != null && program.description!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Text(
+                  program.description!,
+                  style: theme.textTheme.bodyMedium?.copyWith(color: Colors.grey[600]),
+                ),
               ),
+            const Divider(),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text('Plans', style: theme.textTheme.titleMedium),
             ),
-          const Divider(),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Text('Plans', style: theme.textTheme.titleMedium),
-          ),
-          StreamBuilder<QuerySnapshot>(
-            stream: FirebaseFirestore.instance
-                .collection('users')
-                .doc(uid)
-                .collection('plans')
-                .where('programId', isEqualTo: program.id)
-                .snapshots(),
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Padding(
-                  padding: EdgeInsets.all(16),
-                  child: Center(child: CircularProgressIndicator()),
+            StreamBuilder<QuerySnapshot>(
+              stream: FirebaseFirestore.instance
+                  .collection('users')
+                  .doc(uid)
+                  .collection('plans')
+                  .where('programId', isEqualTo: program.id)
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Center(child: CircularProgressIndicator()),
+                  );
+                }
+                final docs = snapshot.data?.docs ?? [];
+                if (docs.isEmpty) {
+                  return Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                    child: Text(
+                      'No plans yet — ask your AI coach to create one.',
+                      style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
+                    ),
+                  );
+                }
+                return Column(
+                  children: docs.map((doc) {
+                    final plan = WorkoutPlan.fromMap(doc.id, doc.data() as Map<String, dynamic>);
+                    return PlanCard(plan: plan);
+                  }).toList(),
                 );
-              }
-              final docs = snapshot.data?.docs ?? [];
-              if (docs.isEmpty) {
-                return Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-                  child: Text(
-                    'No plans yet — ask your AI coach to create one.',
-                    style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
-                  ),
-                );
-              }
-              return Column(
-                children: docs.map((doc) {
-                  final plan = WorkoutPlan.fromMap(doc.id, doc.data() as Map<String, dynamic>);
-                  return PlanCard(plan: plan);
-                }).toList(),
-              );
-            },
-          ),
-          const Divider(),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Text('Workouts', style: theme.textTheme.titleMedium),
-          ),
-          Expanded(
-            child: StreamBuilder<QuerySnapshot>(
+              },
+            ),
+            const Divider(),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text('Workouts', style: theme.textTheme.titleMedium),
+            ),
+            StreamBuilder<QuerySnapshot>(
               stream: FirebaseFirestore.instance
                   .collection('users')
                   .doc(uid)
@@ -107,14 +107,24 @@ class ProgramDetailScreen extends StatelessWidget {
                   .snapshots(),
               builder: (context, snapshot) {
                 if (snapshot.hasError) return Center(child: Text('Error: ${snapshot.error}'));
-                if (snapshot.connectionState == ConnectionState.waiting) return const Center(child: CircularProgressIndicator());
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Center(child: CircularProgressIndicator()),
+                  );
+                }
 
                 final docs = snapshot.data?.docs ?? [];
                 if (docs.isEmpty) {
-                  return const Center(child: Text('No workouts in this program yet.', style: TextStyle(color: Colors.grey)));
+                  return const Padding(
+                    padding: EdgeInsets.all(24),
+                    child: Center(child: Text('No workouts in this program yet.', style: TextStyle(color: Colors.grey))),
+                  );
                 }
 
                 return ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
                   itemCount: docs.length,
                   itemBuilder: (context, index) {
                     final workout = Workout.fromMap(docs[index].id, docs[index].data() as Map<String, dynamic>);
@@ -123,8 +133,8 @@ class ProgramDetailScreen extends StatelessWidget {
                 );
               },
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/video_player.dart
+++ b/lib/widgets/video_player.dart
@@ -21,12 +21,6 @@ class VideoLinkTileState extends State<VideoLinkTile> {
   @override
   void initState() {
     super.initState();
-    // Auto-expand on web — ListTile.onTap doesn't receive pointer events
-    // reliably inside CanvasKit scrollable containers (flutter/flutter#54027).
-    // On web we use a raw iframe via HtmlElementView, no controller needed.
-    if (kIsWeb && _videoId != null) {
-      _isExpanded = true;
-    }
   }
 
   String? get _videoId {
@@ -53,12 +47,7 @@ class VideoLinkTileState extends State<VideoLinkTile> {
     if (widget.url != oldWidget.url) {
       _controller?.close();
       _controller = null;
-      final videoId = _videoId;
-      if (kIsWeb && videoId != null) {
-        _isExpanded = true;
-      } else {
-        _isExpanded = false;
-      }
+      _isExpanded = false;
     }
   }
 
@@ -121,7 +110,7 @@ class VideoLinkTileState extends State<VideoLinkTile> {
           title: Text(widget.title, style: const TextStyle(fontSize: 14)),
           subtitle: Text(
             videoId != null
-              ? (_isExpanded ? (kIsWeb ? 'Reference video' : 'Tap to hide video') : 'Watch reference video')
+              ? (_isExpanded ? 'Tap to hide video' : 'Watch reference video')
               : 'Open link',
             style: const TextStyle(fontSize: 12, color: Colors.grey),
           ),
@@ -179,35 +168,64 @@ class VideoLinkTileState extends State<VideoLinkTile> {
     final videoId = _videoId;
     if (videoId == null) return const SizedBox.shrink();
 
+    // Small clickable thumbnail. Tap opens the YouTube URL in a new browser
+    // tab via _launchUrl (which passes webOnlyWindowName: "_blank").
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-      child: Column(
-        children: [
-          AspectRatio(
-            aspectRatio: 16 / 9,
-            child: HtmlElementView.fromTagName(
-              tagName: 'iframe',
-              onElementCreated: (Object element) {
-                // element is a web Element; use dynamic to call setAttribute
-                final el = element as dynamic;
-                el.setAttribute('src', 'https://www.youtube.com/embed/$videoId?autoplay=0&rel=0');
-                el.setAttribute('style', 'border:none;width:100%;height:100%');
-                el.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture');
-                el.setAttribute('allowfullscreen', 'true');
-              },
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 240),
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: GestureDetector(
+              onTap: _launchUrl,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: AspectRatio(
+                  aspectRatio: 16 / 9,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      Image.network(
+                        'https://img.youtube.com/vi/$videoId/mqdefault.jpg',
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, __, ___) => Container(color: Colors.black12),
+                      ),
+                      Container(color: Colors.black26),
+                      const Center(
+                        child: Icon(
+                          Icons.play_circle_filled,
+                          size: 48,
+                          color: Colors.white,
+                        ),
+                      ),
+                      Positioned(
+                        right: 6,
+                        bottom: 6,
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: Colors.black54,
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: const Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(Icons.open_in_new, size: 12, color: Colors.white),
+                              SizedBox(width: 4),
+                              Text('YouTube', style: TextStyle(color: Colors.white, fontSize: 11)),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
             ),
           ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton.icon(
-                onPressed: _launchUrl,
-                icon: const Icon(Icons.open_in_new, size: 14),
-                label: const Text('Open in YouTube', style: TextStyle(fontSize: 12)),
-              ),
-            ],
-          ),
-        ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary

- **Scroll overflow in program detail screen**: expanded plans were bursting out of the viewport (BOTTOM OVERFLOWED BY 1440 PIXELS). The body now uses \`SingleChildScrollView\` with a shrink-wrapped inner Workouts \`ListView\`, so the whole screen scrolls as one.
- **Scroll trap from inline iframe**: on web, each expanded video rendered a 16:9 \`<iframe>\` that swallowed wheel events. Replaced with a 240px YouTube thumbnail (\`img.youtube.com/vi/<id>/mqdefault.jpg\`) that opens the URL in a new tab on click.
- **Web auto-expand removed**: videos now start collapsed on web, matching mobile. Expand-on-tap, no pre-loaded iframes.

## Test plan

- [x] Open a program with plans containing 8+ exercises — confirm no yellow/black overflow banner
- [x] Scroll smoothly through the full expanded plan
- [x] Tap \"Watch reference video\" → thumbnail appears
- [x] Click thumbnail → YouTube opens in a new tab
- [x] \`flutter analyze\` clean on both edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)