### PR TITLE
Fix mobile scroll; rename Plans to Workouts in UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -62,6 +63,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'FitApp',
       debugShowCheckedModeBanner: false,
+      scrollBehavior: const _AppScrollBehavior(),
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
           seedColor: Colors.teal,
@@ -78,6 +80,23 @@ class MyApp extends StatelessWidget {
       home: const AuthWrapper(),
     );
   }
+}
+
+class _AppScrollBehavior extends MaterialScrollBehavior {
+  const _AppScrollBehavior();
+
+  // Mobile Chrome sometimes reports pointer events as non-touch kinds on
+  // certain builds. Enabling every drag device guarantees scrolling works
+  // across touch, mouse, stylus, and trackpad — including when nested
+  // tappable widgets (e.g. ExpansionTile) are present.
+  @override
+  Set<PointerDeviceKind> get dragDevices => const {
+        PointerDeviceKind.touch,
+        PointerDeviceKind.mouse,
+        PointerDeviceKind.stylus,
+        PointerDeviceKind.trackpad,
+        PointerDeviceKind.unknown,
+      };
 }
 
 class AuthWrapper extends StatefulWidget {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import '../models/workout.dart';
 import '../models/workout_session.dart';
-import '../widgets/workout_card.dart';
 import '../widgets/session_card.dart';
 import 'api_token_screen.dart';
 import 'calendar_screen.dart';
@@ -12,7 +10,6 @@ import '../models/workout_program.dart';
 import 'program_edit_screen.dart';
 import 'faq_screen.dart';
 import 'subscription_screen.dart';
-import 'workout_edit_screen.dart';
 import 'session_edit_screen.dart';
 
 import 'program_detail_screen.dart';
@@ -23,7 +20,7 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 4,
+      length: 3,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('FitApp'),
@@ -70,7 +67,6 @@ class HomeScreen extends StatelessWidget {
             isScrollable: true,
             tabs: [
               Tab(icon: Icon(Icons.folder_copy), text: 'Programs'),
-              Tab(icon: Icon(Icons.fitness_center), text: 'Workouts'),
               Tab(icon: Icon(Icons.calendar_month), text: 'Calendar'),
               Tab(icon: Icon(Icons.history), text: 'Sessions'),
             ],
@@ -79,7 +75,6 @@ class HomeScreen extends StatelessWidget {
         body: const TabBarView(
           children: [
             _ProgramsTab(),
-            _WorkoutsTab(),
             CalendarScreen(),
             _SessionsTab(),
           ],
@@ -189,8 +184,8 @@ class _ProgramCard extends StatelessWidget {
     if (!context.mounted) return;
 
     final content = planCount > 0
-        ? 'This will delete the program and all $planCount plan${planCount == 1 ? '' : 's'} underneath it. Linked workouts will become standalone.'
-        : 'Delete this program? Linked workouts will NOT be deleted but will become standalone.';
+        ? 'This will delete the program and all $planCount workout${planCount == 1 ? '' : 's'} underneath it.'
+        : 'Delete this program?';
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -216,70 +211,6 @@ class _ProgramCard extends StatelessWidget {
     }
   }
 }
-
-class _WorkoutsTab extends StatelessWidget {
-  const _WorkoutsTab();
-
-  @override
-  Widget build(BuildContext context) {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return const Scaffold(body: Center(child: Text('Not authenticated')));
-    final uid = user.uid;
-
-    return Scaffold(
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const WorkoutEditScreen()),
-        ),
-        tooltip: 'Add Workout',
-        child: const Icon(Icons.add),
-      ),
-      body: StreamBuilder<QuerySnapshot>(
-        stream: FirebaseFirestore.instance
-            .collection('users')
-            .doc(uid)
-            .collection('workouts')
-            .orderBy('updatedAt', descending: true)
-            .snapshots(),
-        builder: (context, snapshot) {
-          if (snapshot.hasError) {
-            return Center(child: Text('Something went wrong: ${snapshot.error}'));
-          }
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          final docs = snapshot.data!.docs;
-          if (docs.isEmpty) {
-            return const Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.fitness_center, size: 64, color: Colors.grey),
-                  SizedBox(height: 16),
-                  Text('No workouts yet', style: TextStyle(fontSize: 18, color: Colors.grey)),
-                  SizedBox(height: 8),
-                  Text('Tap + to create your first workout', style: TextStyle(color: Colors.grey)),
-                ],
-              ),
-            );
-          }
-
-          return ListView.builder(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            itemCount: docs.length,
-            itemBuilder: (context, index) {
-              final workout = Workout.fromMap(
-                  docs[index].id, docs[index].data()! as Map<String, dynamic>);
-              return WorkoutCard(workout: workout);
-            },
-          );
-        },
-      ),
-    );
-  }
-}
-
 
 class _SessionsTab extends StatelessWidget {
   const _SessionsTab();

--- a/lib/screens/program_detail_screen.dart
+++ b/lib/screens/program_detail_screen.dart
@@ -2,11 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../models/workout_program.dart';
-import '../models/workout.dart';
 import '../models/workout_plan.dart';
-import '../widgets/workout_card.dart';
 import '../widgets/plan_card.dart';
-import 'workout_edit_screen.dart';
 
 class ProgramDetailScreen extends StatelessWidget {
   final WorkoutProgram program;
@@ -21,120 +18,57 @@ class ProgramDetailScreen extends StatelessWidget {
     final uid = user.uid;
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(program.name),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.add),
-            tooltip: 'Add Workout to Program',
-            onPressed: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => WorkoutEditScreen(
-                  workout: Workout(
-                    id: '',
-                    name: '',
-                    type: 'strength',
-                    exercises: [],
-                    programId: program.id,
+      appBar: AppBar(title: Text(program.name)),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('users')
+            .doc(uid)
+            .collection('plans')
+            .where('programId', isEqualTo: program.id)
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final docs = snapshot.data?.docs ?? [];
+          final hasDescription =
+              program.description != null && program.description!.isNotEmpty;
+
+          return ListView.builder(
+            padding: const EdgeInsets.only(bottom: 24),
+            itemCount: 2 + (docs.isEmpty ? 1 : docs.length),
+            itemBuilder: (context, index) {
+              if (index == 0) {
+                if (!hasDescription) return const SizedBox.shrink();
+                return Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Text(
+                    program.description!,
+                    style: theme.textTheme.bodyMedium?.copyWith(color: Colors.grey[600]),
                   ),
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-      body: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (program.description != null && program.description!.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Text(
-                  program.description!,
-                  style: theme.textTheme.bodyMedium?.copyWith(color: Colors.grey[600]),
-                ),
-              ),
-            const Divider(),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Text('Plans', style: theme.textTheme.titleMedium),
-            ),
-            StreamBuilder<QuerySnapshot>(
-              stream: FirebaseFirestore.instance
-                  .collection('users')
-                  .doc(uid)
-                  .collection('plans')
-                  .where('programId', isEqualTo: program.id)
-                  .snapshots(),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Center(child: CircularProgressIndicator()),
-                  );
-                }
-                final docs = snapshot.data?.docs ?? [];
-                if (docs.isEmpty) {
-                  return Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-                    child: Text(
-                      'No plans yet — ask your AI coach to create one.',
-                      style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
-                    ),
-                  );
-                }
-                return Column(
-                  children: docs.map((doc) {
-                    final plan = WorkoutPlan.fromMap(doc.id, doc.data() as Map<String, dynamic>);
-                    return PlanCard(plan: plan);
-                  }).toList(),
                 );
-              },
-            ),
-            const Divider(),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Text('Workouts', style: theme.textTheme.titleMedium),
-            ),
-            StreamBuilder<QuerySnapshot>(
-              stream: FirebaseFirestore.instance
-                  .collection('users')
-                  .doc(uid)
-                  .collection('workouts')
-                  .where('programId', isEqualTo: program.id)
-                  .snapshots(),
-              builder: (context, snapshot) {
-                if (snapshot.hasError) return Center(child: Text('Error: ${snapshot.error}'));
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Center(child: CircularProgressIndicator()),
-                  );
-                }
-
-                final docs = snapshot.data?.docs ?? [];
-                if (docs.isEmpty) {
-                  return const Padding(
-                    padding: EdgeInsets.all(24),
-                    child: Center(child: Text('No workouts in this program yet.', style: TextStyle(color: Colors.grey))),
-                  );
-                }
-
-                return ListView.builder(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  itemCount: docs.length,
-                  itemBuilder: (context, index) {
-                    final workout = Workout.fromMap(docs[index].id, docs[index].data() as Map<String, dynamic>);
-                    return WorkoutCard(workout: workout);
-                  },
+              }
+              if (index == 1) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  child: Text('Workouts', style: theme.textTheme.titleMedium),
                 );
-              },
-            ),
-          ],
-        ),
+              }
+              if (docs.isEmpty) {
+                return Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                  child: Text(
+                    'No workouts yet — ask your AI coach to create one.',
+                    style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
+                  ),
+                );
+              }
+              final doc = docs[index - 2];
+              final plan = WorkoutPlan.fromMap(doc.id, doc.data() as Map<String, dynamic>);
+              return PlanCard(plan: plan);
+            },
+          );
+        },
       ),
     );
   }

--- a/lib/widgets/plan_card.dart
+++ b/lib/widgets/plan_card.dart
@@ -13,7 +13,7 @@ class PlanCard extends StatelessWidget {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Delete Plan'),
+        title: const Text('Delete Workout'),
         content: Text('Delete "${plan.name}"? This cannot be undone.'),
         actions: [
           TextButton(
@@ -57,7 +57,7 @@ class PlanCard extends StatelessWidget {
             IconButton(
               icon: const Icon(Icons.delete_outline, color: Colors.red, size: 20),
               onPressed: () => _deletePlan(context),
-              tooltip: 'Delete Plan',
+              tooltip: 'Delete Workout',
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(),
             ),


### PR DESCRIPTION
## Summary
- Fixes stuck scrolling on mobile Chrome when plan cards are expanded in program detail: adds a `MaterialScrollBehavior` with all `PointerDeviceKind`s in `dragDevices` and swaps the nested `SingleChildScrollView + Column` for a `ListView.builder`.
- Renames user-facing **Plans → Workouts** in the program detail screen header, empty state, and delete-plan dialog text. Firestore collections, model classes, and MCP tool names stay as-is — no data migration needed.
- Removes the dead flat-Workouts UI (Home tab + the "Workouts" section inside program detail) since the name now collides with the renamed label and that flow was unused. The `workouts` Firestore collection and `Workout` model remain intact.

## Test plan
- [x] `flutter analyze` — no new errors on edited files
- [x] `flutter test test/widgets/plan_card_test.dart` — 4/4 pass
- [x] `flutter run -d chrome` — launches cleanly, no runtime errors
- [ ] Manual check on mobile Chrome: verify scroll still works inside a program with one or more plan cards expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)