### PR TITLE
fix: support video upload on Flutter web via putData

### DIFF
--- a/lib/services/exercise_video_service.dart
+++ b/lib/services/exercise_video_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/foundation.dart';
 import 'package:image_picker/image_picker.dart';
 
 class ExerciseVideoUpload {
@@ -39,10 +40,10 @@ class ExerciseVideoService {
         'users/$uid/sessions/$sessionId/entries/$entryDocId/$timestamp.mp4';
 
     final ref = FirebaseStorage.instance.ref(path);
-    final task = ref.putFile(
-      File(file.path),
-      SettableMetadata(contentType: 'video/mp4'),
-    );
+    final metadata = SettableMetadata(contentType: 'video/mp4');
+    final task = kIsWeb
+        ? ref.putData(await file.readAsBytes(), metadata)
+        : ref.putFile(File(file.path), metadata);
 
     if (onProgress != null) {
       task.snapshotEvents.listen((snap) {


### PR DESCRIPTION
## Summary
- `ExerciseVideoService.upload` used `dart:io` `File(file.path)` + `ref.putFile(...)`, which fails on Flutter web since `image_picker` returns a blob URL rather than a real filesystem path.
- Added a `kIsWeb` branch that uses `ref.putData(await file.readAsBytes(), ...)` on web while keeping `putFile` on native platforms.

## Test plan
- [ ] `flutter analyze` passes (verified locally: no issues)
- [ ] Record/pick a video on web and confirm it uploads to Firebase Storage and the download URL renders in the session entry
- [ ] Record/pick a video on iOS/Android and confirm upload still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)