### PR TITLE
docs: pilot bounty program with GitHub Sponsors payout

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [nick-transition]

--- a/.github/ISSUE_TEMPLATE/bounty_proposal.md
+++ b/.github/ISSUE_TEMPLATE/bounty_proposal.md
@@ -1,0 +1,59 @@
+---
+name: Bounty Proposal
+about: Propose a roadmap item be turned into a paid bounty
+title: '[Bounty Proposal] '
+labels: bounty-proposal
+---
+
+<!--
+Use this template to propose a roadmap (or roadmap-adjacent) issue for a
+paid bounty. A maintainer will review, tighten scope if needed, and convert
+approved proposals into the live bountied issue.
+
+See BOUNTIES.md for how the program works.
+-->
+
+## Roadmap item
+
+<!-- Link to the roadmap bullet or existing issue this would turn into a bounty. -->
+
+Related issue: #
+
+## Scope — must ship
+
+<!-- Numbered list. Be specific about files and behaviors. -->
+
+1.
+2.
+3.
+
+## Out of scope
+
+<!-- Explicit non-goals. This is what keeps the bounty from ballooning. -->
+
+-
+-
+
+## Acceptance criteria
+
+<!-- The checklist a PR must satisfy to earn the bounty. -->
+
+- [ ]
+- [ ]
+- [ ] PR uses the AI-disclosure template
+- [ ] CI green (`pr-check.yml`, `e2e.yml`)
+- [ ] No regressions in existing flows
+
+## Size estimate
+
+- [ ] S (<50 lines, $100–$200)
+- [ ] M (50–200 lines, $300–$600)
+- [ ] L (200+ lines, $800–$2000)
+
+## Suggested bounty amount
+
+$
+
+## Notes for the implementer
+
+<!-- Links to relevant files, prior art, gotchas. Optional but appreciated. -->

--- a/BOUNTIES.md
+++ b/BOUNTIES.md
@@ -1,0 +1,66 @@
+# Bounties
+
+FitApp pilots a **fixed-dollar bounty program** for select roadmap items. Bounties are paid via a one-time [GitHub Sponsors](https://github.com/sponsors) sponsorship on PR merge. They are **in addition to** the [revenue-pool contribution points](CONTRIBUTING.md) — claiming a bounty does not reduce your monthly pool share.
+
+> **Trust-based, no escrow.** There's no platform holding funds. Maintainer commits publicly in the issue to pay on merge; payment happens within 48 hours of merge. If this is a blocker for you, don't claim — open an issue instead and we'll discuss.
+
+## How it works
+
+1. A maintainer opens an issue labeled [`bounty`](https://github.com/nick-transition/fitapp/issues?q=is%3Aissue+label%3Abounty) with scope, acceptance criteria, and a dollar amount stated in the issue body.
+2. You comment on the issue saying you're attempting it (`"I'd like to work on this"` is fine — this isn't slash-command-driven). A maintainer replies to approve, which marks the bounty claimed so others don't duplicate work.
+3. You open a PR that says `Closes #N`, follows the PR template (including AI disclosure), and meets the acceptance criteria.
+4. On merge, the maintainer sends you a one-time GitHub Sponsors sponsorship for the stated amount.
+
+## Receiving payment
+
+Preferred: you have [GitHub Sponsors](https://github.com/sponsors) enabled on your account to receive a one-time sponsorship. Setup is free and takes ~10 minutes.
+
+If you can't use GitHub Sponsors (not available in your region, don't want to set it up for $100, etc.), mention it in the PR and we'll arrange PayPal, Wise, or a direct Stripe invoice instead.
+
+## What a bountied issue looks like
+
+Every bountied issue has:
+
+- **Scope** — a numbered list of what must ship
+- **Out of scope** — explicit non-goals to prevent scope creep
+- **Acceptance criteria** — the checklist a PR must satisfy
+- **Size** — S / M / L (drives the bounty $)
+- A maintainer comment stating the dollar amount and payment commitment
+
+## Sizing
+
+| Size | Lines | Scope hint | Suggested $ |
+|------|-------|------------|-------------|
+| S    | <50   | Config, single widget, docs fix | $100–$200 |
+| M    | 50–200 | Feature touching 2–4 files, tests included | $300–$600 |
+| L    | 200+  | New screen, new service, or migration | $800–$2000 |
+
+## Relationship to the revenue pool
+
+Bounties are separate from, and additive to, the 25% revenue pool described in
+[CONTRIBUTING.md](CONTRIBUTING.md) and
+[docs/proposals/stripe-monetization/open-source-strategy.md](docs/proposals/stripe-monetization/open-source-strategy.md).
+
+A merged bountied PR:
+- Triggers the GitHub Sponsors bounty payout within 48 hours
+- Still earns you PR points (S=1, M=3, L=5) toward the monthly pool distribution
+
+## Proposing a new bounty
+
+Roadmap items only become bounties once they have tight scope and acceptance
+criteria. To propose one, open a [Bounty Proposal](.github/ISSUE_TEMPLATE/bounty_proposal.md)
+issue. A maintainer converts approved proposals into the live bountied issue.
+
+## Etiquette
+
+- Don't claim more than one bounty at a time without merging the prior one.
+- If a claimed bounty goes quiet for 14+ days with no PR, the maintainer releases it back to the queue.
+- Ambiguous scope → ask in the issue before starting. Clarifications are free.
+
+## Why GitHub Sponsors (and not a bounty platform)?
+
+As of April 2026, the two established bounty platforms (Algora and Polar) have both pivoted away from self-serve issue bounties — Algora toward recruiting, Polar toward SaaS billing. Rather than fight the platform question for a small pilot, bounties here are paid directly via GitHub Sponsors on merge. If the pilot scales, we'll revisit OpenCollective or a rolled-own escrow.
+
+## History
+
+_First bounty pending — this section will track completed bounties, time-to-merge, and any scope adjustments once the pilot runs._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thank you for your interest in contributing to FitApp! This project is built as a protocol-style open source company where contributors earn from the revenue pool.
 
+## Bounties
+
+Select roadmap items have fixed-dollar bounties paid via a one-time [GitHub Sponsors](https://github.com/sponsors) sponsorship on PR merge. Bounties are **additive to** the revenue-pool points below — a bountied PR earns both. See [BOUNTIES.md](BOUNTIES.md) for the workflow (claiming, acceptance criteria, sizing).
+
+Browse open bounties: [issues labeled `bounty`](https://github.com/nick-transition/fitapp/issues?q=is%3Aissue+label%3Abounty).
+
 ## How Contributors Earn
 
 FitApp allocates 25% of subscription revenue to the contributor pool. Contributions are scored based on:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ E2e tests record video of each test run and capture screenshots of every major s
 
 Contributors earn from FitApp's revenue pool — 25% of subscription revenue is distributed monthly based on contribution points.
 
+Select roadmap items also have fixed-dollar **bounties** paid via a one-time [GitHub Sponsors](https://github.com/sponsors) sponsorship on PR merge — additive to the revenue-pool points. See [BOUNTIES.md](BOUNTIES.md).
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor scoring model, AI usage standards, and code guidelines.
 
 ## License


### PR DESCRIPTION
## Summary
- Adds `BOUNTIES.md` describing the fixed-dollar bounty program paid via one-time GitHub Sponsors sponsorships on PR merge (trust-based, 48h payout commitment, PayPal/Wise fallback)
- Adds `.github/ISSUE_TEMPLATE/bounty_proposal.md` for proposing new bounties
- Adds a **Bounties** section to `CONTRIBUTING.md` and a bounty blurb to the `README.md` Contributing section
- Pilot bounty is [#3](https://github.com/nick-transition/fitapp/issues/3) at \$100 (size M)

## Why GitHub Sponsors (not Algora/Polar)
As of April 2026 both Algora and Polar have pivoted away from self-serve issue bounties. For a small pilot, paying directly via GitHub Sponsors on merge is simpler than fighting the platform question. If the pilot scales, we'll revisit OpenCollective or a rolled-own escrow.

## Test plan
- [ ] Verify `BOUNTIES.md` renders on GitHub
- [ ] Verify bounty proposal template appears in the New Issue picker
- [ ] Verify README and CONTRIBUTING links resolve
- [ ] Post \$100 payout commitment comment on #3 once this merges so the bounty is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)