### PR TITLE
Harden OAuth client and token validation

### DIFF
--- a/functions/src/auth.ts
+++ b/functions/src/auth.ts
@@ -1,5 +1,6 @@
 import * as admin from 'firebase-admin';
 import { Request } from 'firebase-functions/v2/https';
+import { isOAuthTokenExpired } from './oauthSecurity.js';
 
 /**
  * Resolves the authenticated user from the request.
@@ -48,6 +49,11 @@ export async function resolveUser(req: Request): Promise<AuthContext> {
   const oauthDoc = await admin.firestore().doc(`oauthTokens/${token}`).get();
   if (oauthDoc.exists) {
     const data = oauthDoc.data()!;
+    if (isOAuthTokenExpired(data)) {
+      await admin.firestore().doc(`oauthTokens/${token}`).delete();
+      throw new Error('Invalid credentials');
+    }
+
     let scopes = (data.scope as string || 'profile:read workout:read').split(' ');
     
     // If Claude requested the generic 'claudeai' scope, grant full workout access

--- a/functions/src/oauth.ts
+++ b/functions/src/oauth.ts
@@ -1,6 +1,12 @@
 import * as admin from 'firebase-admin';
 import * as crypto from 'crypto';
 import { defineSecret } from 'firebase-functions/params';
+import {
+  OAUTH_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+  createOAuthTokenExpiry,
+  isClientSecretValid,
+  isRedirectUriAllowed,
+} from './oauthSecurity.js';
 
 // Define the secret (it will be injected from Secret Manager)
 export const FIREBASE_API_KEY = defineSecret('APP_FIREBASE_API_KEY');
@@ -146,6 +152,10 @@ export async function handleOAuthRequest(req: any, res: any) {
         res.status(400).json({ error: 'Invalid client_id' });
         return;
       }
+      if (!isRedirectUriAllowed(clientDoc.data()!, redirect_uri)) {
+        res.status(400).json({ error: 'Invalid redirect_uri' });
+        return;
+      }
 
       const params = new URLSearchParams({ 
         client_id, 
@@ -163,6 +173,15 @@ export async function handleOAuthRequest(req: any, res: any) {
       const { client_id, redirect_uri, state, scope } = req.query as Record<string, string>;
       if (!client_id || !redirect_uri || !state) {
         res.status(400).json({ error: 'Missing required parameters' });
+        return;
+      }
+      const clientDoc = await admin.firestore().doc(`oauthClients/${client_id}`).get();
+      if (!clientDoc.exists) {
+        res.status(400).json({ error: 'Invalid client_id' });
+        return;
+      }
+      if (!isRedirectUriAllowed(clientDoc.data()!, redirect_uri)) {
+        res.status(400).json({ error: 'Invalid redirect_uri' });
         return;
       }
 
@@ -183,6 +202,10 @@ export async function handleOAuthRequest(req: any, res: any) {
       const clientDoc = await admin.firestore().doc(`oauthClients/${clientId}`).get();
       if (!clientDoc.exists) {
         res.status(400).json({ error: 'Invalid client_id' });
+        return;
+      }
+      if (!isRedirectUriAllowed(clientDoc.data()!, redirectUri)) {
+        res.status(400).json({ error: 'Invalid redirect_uri' });
         return;
       }
 
@@ -229,7 +252,7 @@ export async function handleOAuthRequest(req: any, res: any) {
 
       // Validate client credentials
       const clientDoc = await admin.firestore().doc(`oauthClients/${client_id}`).get();
-      if (!clientDoc.exists || clientDoc.data()!.secret !== client_secret) {
+      if (!clientDoc.exists || !isClientSecretValid(clientDoc.data()!.secret, client_secret)) {
         res.status(401).json({ error: 'invalid_client' });
         return;
       }
@@ -268,6 +291,7 @@ export async function handleOAuthRequest(req: any, res: any) {
         clientId: client_id,
         scope: codeData.scope, // Inherit scope from authorization code
         createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        expiresAt: createOAuthTokenExpiry(),
       });
 
       // Delete used code
@@ -276,6 +300,7 @@ export async function handleOAuthRequest(req: any, res: any) {
       res.status(200).json({
         access_token: accessToken,
         token_type: 'Bearer',
+        expires_in: OAUTH_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
         scope: codeData.scope,
       });
       return;

--- a/functions/src/oauthSecurity.ts
+++ b/functions/src/oauthSecurity.ts
@@ -1,0 +1,72 @@
+import * as crypto from 'crypto';
+import * as admin from 'firebase-admin';
+
+export const OAUTH_ACCESS_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+export const OAUTH_ACCESS_TOKEN_EXPIRES_IN_SECONDS = Math.floor(OAUTH_ACCESS_TOKEN_TTL_MS / 1000);
+
+interface OAuthClientData {
+  redirectUris?: unknown;
+  redirectUri?: unknown;
+  secret?: unknown;
+}
+
+interface OAuthTokenData {
+  createdAt?: unknown;
+  expiresAt?: unknown;
+}
+
+function toDate(value: unknown): Date | undefined {
+  if (value instanceof Date) {
+    return value;
+  }
+  if (value && typeof value === 'object' && 'toDate' in value && typeof value.toDate === 'function') {
+    return value.toDate() as Date;
+  }
+  return undefined;
+}
+
+export function createOAuthTokenExpiry(now = Date.now()): admin.firestore.Timestamp {
+  return admin.firestore.Timestamp.fromDate(new Date(now + OAUTH_ACCESS_TOKEN_TTL_MS));
+}
+
+export function isOAuthTokenExpired(data: OAuthTokenData, now = Date.now()): boolean {
+  const expiresAt = toDate(data.expiresAt);
+  if (expiresAt) {
+    return expiresAt.getTime() <= now;
+  }
+
+  const createdAt = toDate(data.createdAt);
+  if (!createdAt) {
+    return true;
+  }
+
+  return createdAt.getTime() + OAUTH_ACCESS_TOKEN_TTL_MS <= now;
+}
+
+export function isRedirectUriAllowed(clientData: OAuthClientData, redirectUri: string): boolean {
+  try {
+    new URL(redirectUri);
+  } catch {
+    return false;
+  }
+
+  const redirectUris = Array.isArray(clientData.redirectUris)
+    ? clientData.redirectUris.filter((uri): uri is string => typeof uri === 'string')
+    : [];
+
+  if (typeof clientData.redirectUri === 'string') {
+    redirectUris.push(clientData.redirectUri);
+  }
+
+  return redirectUris.includes(redirectUri);
+}
+
+export function isClientSecretValid(storedSecret: unknown, providedSecret: unknown): boolean {
+  if (typeof storedSecret !== 'string' || typeof providedSecret !== 'string') {
+    return false;
+  }
+
+  const storedHash = crypto.createHash('sha256').update(storedSecret).digest();
+  const providedHash = crypto.createHash('sha256').update(providedSecret).digest();
+  return crypto.timingSafeEqual(storedHash, providedHash);
+}


### PR DESCRIPTION
## Summary

Fixes three related OAuth security issues:

- Fixes #6 by validating `redirect_uri` against the registered OAuth client redirect URIs on `/authorize`, `/login`, and `/callback`.
- Fixes #7 by issuing OAuth access tokens with a 90-day `expiresAt`, returning `expires_in`, and rejecting/removing expired OAuth tokens during `resolveUser`.
- Fixes #8 by replacing direct client-secret comparison with a fixed-length SHA-256 digest comparison using `crypto.timingSafeEqual`.

## Notes

The redirect URI helper accepts the current expected `redirectUris` array and also supports a legacy single `redirectUri` string if any existing client documents use that shape.

For existing OAuth tokens without `expiresAt`, validation falls back to `createdAt + 90 days`; tokens without either timestamp are rejected.

## Validation

- `npm ci` in `functions/`
- `npm run build` in `functions/`
- `git diff --check`

I saw the earlier discussion about treating these as S-size security fixes under `BOUNTIES.md`. If you are open to formalizing the three related fixes together, I would be happy to coordinate the payout process you prefer after review.